### PR TITLE
add hover effect on card

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,10 +469,12 @@
                 <div class="flip">A delightful blend of crunchy nuts and rich butterscotch, creating a sweet and savory treat that melts in your mouth!</div>
             </div>
                 <div class="price"> $15.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
-
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
+              
 
           </div>
         
@@ -486,10 +488,12 @@
             </div>
 
                 <div class="price"> $18.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Berry Pops', 18.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Berry Pops', 18.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='berry_pops.html';">Read more</button>
-
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
+              
 
             </div>
         
@@ -504,10 +508,12 @@
                 </div>
 
                 <div class="price"> $18.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Cherry Sherbet Pops', 18.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Cherry Sherbet Pops', 18.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='cherry_pops.html';">Read more</button>
-
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
+              
 
             </div>
         
@@ -526,9 +532,12 @@
 
         
                 <div class="price"> $15.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Dripping Vannila', 15.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Dripping Vannila', 15.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='drip_vanilla.html';">Read more</button>
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
+              
             </div>
 
             <div class="box"  data-aos="fade-right" data-aos-duration="1200" data-aos-delay="200"
@@ -544,9 +553,12 @@
 
        
                 <div class="price"> $16.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Very Berry Strawberry', 16.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Very Berry Strawberry', 16.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='very_straw.html';">Read more</button>
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
+              
             </div>
 
             <div class="box"  data-aos="fade-up" data-aos-duration="1200" data-aos-delay="200"
@@ -561,9 +573,12 @@
  
             
                 <div class="price"> $18.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Rainbow Classic Cone', 18.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Rainbow Classic Cone', 18.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='rain_classic.html';">Read more</button>
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
+              
             </div>
 
             <div class="box"  data-aos="fade-up" data-aos-duration="1200" data-aos-delay="200"
@@ -579,10 +594,11 @@
             
 
                 <div class="price"> $12.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Orange Pops', 12.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Orange Pops', 12.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='orange_pops.html';">Read more</button>
-
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
             </div>
 
             <div class="box"  data-aos="fade-left" data-aos-duration="1200" data-aos-delay="200"
@@ -598,10 +614,11 @@
 
             
                 <div class="price"> $18.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Choco-Hazel Pops', 18.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Choco-Hazel Pops', 18.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='choco_hazel.html';">Read more</button>
-
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
             </div>
 
             <div class="box"  data-aos="fade-right" data-aos-duration="1200" data-aos-delay="200"
@@ -615,9 +632,11 @@
             </div>
 
                 <div class="price"> $15.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Very Very Peachy',15.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Very Very Peachy', 15.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='very_peachy.html';">Read more</button>
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
             </div>
         
 
@@ -632,9 +651,11 @@
                 <div class="flip">Refreshing frozen delights bursting with zesty orange flavor, offering a sunny, sweet, and tangy treat that’s perfect for cooling off on a hot day!</div>
             </div>
                 <div class="price"> $12.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Orange Pops', 12.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Orange Pops', 12.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='orange_pops1.html';">Read more</button>
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
             </div>
             
 
@@ -650,9 +671,11 @@
             </div>
 
                 <div class="price"> $18.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Choco-Hazel Pops', 18.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Choco-Hazel Pops', 18.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='choco_hazel.html';">Read more</button>
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
             </div>
        
 
@@ -663,16 +686,16 @@
                 <img src="https://images.unsplash.com/photo-1499638472904-ea5c6178a300" alt="">
 
                 <h3 id="pro-name">Very Very Peachy</h3>
-                <div class="price"> $16.99 <span>20.99</span></div>
 
                 <div class="flip">A refreshing and juicy delight packed with the sweet, sunny flavor of ripe peaches, delivering a taste of summer in every delicious bite!</div>
             </div>
 
                 <div class="price"> $15.99 <span>20.99</span></div>
-                <button  id="inbox" onclick="addToCart('Very Very Peachy',15.99)">Add to Cart</button><br>
-                <button  id="inbox" onclick="addToWishlist('Very Very Peachy', 15.99)">Add to wishlist</button>
-                <button id="inbox" onclick="window.location.href='very_peachy2.html';">Read more</button>
-
+                <div class="button-container">
+                  <button id="inbox" onclick="addToCart('Nutty Butterscotch', 15.99)">Add to Cart</button>
+                  <button id="inbox" onclick="addToWishlist('Nutty Butterscoth', 15.99)">Add to wishlist</button>
+                  <button id="inbox" onclick="window.location.href='nut_butter.html';">Read more</button>
+              </div>
 
             </div>
 

--- a/style.css
+++ b/style.css
@@ -764,77 +764,98 @@ button:hover {
 #menu {
   background-color: var(--background-color);
 }
+
+
+/* Container for the card layout */
 .menu .box-container {
   display: flex;
-  flex-direction: row;
   flex-wrap: wrap;
-  height: auto;
-  width: auto;
   justify-content: space-around;
   align-items: center;
+  gap: 20px; 
+  perspective: 1000px; 
 }
 
+
 .menu .box-container .box {
-  margin: 2rem;
-  padding: 0.7rem;
-  border-radius: 8px;
-  border-width: 1.1rem;
-  border-color: var(--text-color);
-  background-color: #d2a679;
-  /* border: 1px solid brown; */
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2), 0 6px 20px rgba(0, 0, 0, 0.19);
-  text-align: center;
-  border: var(--text-color);
-  align-items: center;
+  position: relative;
+  overflow: hidden;
+  background-color: #f8f3eb;
+  border-radius: 12px;
+  box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.15);
+  transition: transform 0.3s ease, box-shadow 0.4s ease;
+  width: 280px; 
+  height: 450px; 
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between; 
 }
+
+
+.menu .box-container .box:hover {
+  transform: translateY(-12px); 
+  box-shadow: 0px 12px 24px rgba(0, 0, 0, 0.2); 
+}
+
 
 .menu .box-container .box h3 {
   padding-top: 10px;
-  color: var(--text-color);
-  font-size: 1.9rem;
-  font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif;
-  color: var(--text-color);
+  color: #4e1a22;
+  font-size: 1.8rem;
+  font-family: 'Cambria', serif;
+  text-align: center;
 }
+
 
 .menu .box-container .box .price {
-  color: var(--text-color);
+  color: #4e1a22;
   font-size: 1.6rem;
-  font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif;
-  color: var(--text-color);
+  font-family: 'Cambria', serif;
+  text-align: center;
+  margin-top: 10px;
 }
 
+
 .menu .box-container .box .price span {
-  color: var(--text-color);
+  color: #d3ad7f; 
   font-size: 1.2rem;
   text-decoration: line-through;
-  font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif;
-  color: var(--text-color);
+  font-family: 'Cambria', serif;
 }
 
 .menu img {
-  width: 220px;
-  height: 220px;
-  border-radius: 1rem;
+  width: 100%;
+  height: 220px; 
+  object-fit: cover; 
+  border-radius: 10px;
   transition: transform 0.5s ease-in-out;
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
 }
 
-.menu .picture {
-  position: relative; /* Added to position the .flip div correctly */
+
+.menu img:hover {
+  transform: scale(1.05) rotateY(10deg); 
+}
+
+.menu .box-container .box .picture {
+  position: relative;
+  width: 100%;
+  height: 220px; 
+  overflow: hidden; 
+  border-radius: 10px; 
   perspective: 1000px;
 }
 
 /* CSS for flip element */
 .menu .flip {
-  width: 220px;
+  width: 100%;
   height: 220px;
-  border-radius: 1rem;
+  border-radius: 10px;
   transition: transform 0.5s ease-in-out;
   background: linear-gradient(135deg, #d5006d, #9c0b2d);
   color: #ffffff;
   font-size: 1.6rem;
-  font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif;
+  font-family: 'Cambria', serif;
   font-weight: bold;
   display: flex;
   align-items: center;
@@ -844,43 +865,50 @@ button:hover {
   left: 0;
   backface-visibility: hidden;
   transform: rotateY(180deg);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
-  border: 2px solid #ffffff;
-  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.5);
-  padding: 10px;
 }
 
 .picture:hover img {
-  transform: rotateY(180deg); /* Rotate the image on hover */
+  transform: rotateY(180deg);
 }
 
 .picture:hover .flip {
-  transform: rotateY(0); /* Show the .flip text on hover */
+  transform: rotateY(0);
 }
 
-.box:hover {
-  transform: scale(1.05);
-  transition-duration: 0.6s;
+.menu .box-container .box .button-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center; 
+  width: 100%;
 }
+
 
 #inbox {
   background-color: #fff8e7;
-  border: 0.5px solid #c69861;
-  color: #d3ad7f;
-  width: fit-content;
-  transition: background-color 0.3s ease, color 0.3s ease,
-    border-color 0.3s ease;
+  border: 1px solid #c69861;
+  color: #4e1a22;
+  width: 90%; 
+  padding: 10px;
+  margin: 5px 0; 
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+  text-align: center;
+  font-size: 1.4rem;
+  font-family: 'Cambria', serif;
+  border-radius: 6px;
+  display: block;
+  box-sizing: border-box;
+}
+
+/* Hover effect for buttons */
+#inbox:hover {
+  color: #ca7c1d;
+  border-color: #b89b57;
+  background-color: #faebd7;
 }
 
 #pro-name {
   color: #4e1a22;
-}
-
-#inbox:hover {
-  /* background-color: #d3ad7f; Darkens background on hover */
-  color: #ca7c1d; /* Lightens text color on hover */
-  border-color: #b89b57; /* Subtle change in border color */
-  background-color: beige;
+  text-align: center; /* Center the product name */
 }
 /*review section style contributed*/
 /* Review Section Adjusted Styles */


### PR DESCRIPTION
### **Fixes #387** 

### **Description:**
This update introduces a simple hover effect to make the cards more interactive, improving user engagement and overall experience.

### **Changes Made:**

- Scale Effect: Slightly scale up the card when hovered to draw attention.
- Shadow Effect: Add a subtle shadow on hover to make the card visually pop.
- Smooth Transition: Implement a 0.3s transition to ensure a smooth, polished hover effect.

### **Video:**


https://github.com/user-attachments/assets/a21639f6-80b1-4859-b3fe-0174ed3ec454

