### PR TITLE
Blog page dark mode update

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -69,8 +69,19 @@
         }
         .btn:hover {
             background-color: #ff6347;
+            color: #151515;
             transform: scale(1.05);
         }
+        [data-theme="dark"] {
+            --background-color: #151515;
+            --text-color: #ffffff;
+            .site-title{
+                color: #ff6b51;
+            }
+            #mode-label{
+                color: white;
+            }
+}
     </style>
 </head>
 <body>
@@ -255,6 +266,6 @@
         domain="www.chatbase.co"
         defer>
         </script>
-        <script src="./darkMode.js"></script>
+        <script src="darkMode.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Solves issue #654 
1) in navbar -> arctic delight was not visible in dark mode -> solved now


<img width="1440" alt="Screenshot 2024-10-21 at 3 59 45 PM" src="https://github.com/user-attachments/assets/362c4c33-2e8e-4189-adde-fba4caa19124">

2) while hovering on button -> read more text was not visible -> solved now

<img width="1164" alt="Screenshot 2024-10-21 at 3 59 56 PM" src="https://github.com/user-attachments/assets/ed4b5900-6335-40af-9ed0-92342e16123f">
