### PR TITLE
Fixed Overlapping Cart, Wishlist, and Search Bars in Navbar

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
         searchForm.classList.toggle('active');
         navbar.classList.remove('active');
         cartItem.classList.remove('active');
+        wishlistContainer.classList.remove('active');
+
     };
 
     document.querySelector('#cart-btn').onclick = () => {
@@ -21,6 +23,8 @@ document.addEventListener('DOMContentLoaded', () => {
         myOrderContainer.classList.remove('active');
         navbar.classList.remove('active');
         searchForm.classList.remove('active');
+        wishlistContainer.classList.remove('active');
+
     };
 
     document.querySelector('#my-order-btn').onclick = () => {
@@ -49,6 +53,8 @@ document.addEventListener('DOMContentLoaded', () => {
         navbar.classList.remove('active');
         searchForm.classList.remove('active');
         cartItem.classList.remove('active');
+        wishlistContainer.classList.remove('active');
+
     };
     function filterItems() {
         const selectedPrice = priceFilter.value;


### PR DESCRIPTION
**Description**
I fixed the issue where previously opened bars (Cart, Wishlist, Search) did not close automatically when a new button was clicked. This fix enhances the user experience by preventing multiple bars from being open simultaneously, which previously caused overlapping or hidden bars.

**How It Works:**

1. Auto-close Bars: When a user clicks the 'View Cart,' 'View Wishlist,' or 'Search' buttons, any previously opened bar (Cart, Wishlist, Search) is automatically closed.
2. Improved User Experience: This prevents overlapping bars and ensures the newly opened bar is always visible, without being hidden behind others.

**Usage:**

1. Click the 'View Cart,' 'View Wishlist,' or 'Search' buttons in the navbar.
2. The previously opened bar will close automatically, ensuring only one bar is visible at a time.

**Fixes:**
Fixes issue #588 .

**Video:**
Before:

https://github.com/user-attachments/assets/c8634265-6cc3-4c78-885e-f0d231eb095b

After:


https://github.com/user-attachments/assets/cdc85964-f747-4d27-b228-ada3e99a1bb1

**Checklist:**

- Tests have been added or updated to cover the changes.
- Code follows the established coding style guidelines.
- All tests are passing.


@dohinafs If the change is acceptable, kindly merge and **assign this PR to me.** **Please add the labels: hacktoberfest-accepted, gssoc-ext, and any appropriate level label.** Thank you! 

