### PR TITLE
[FIXED] Font size of heading too small #755

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -49,7 +49,7 @@
         .blog h3 {
             padding: 15px;
             margin: 0;
-            font-size: 1.2em;
+            font-size: 2em;
             color: #2c3e50;
         }
         .blog p {


### PR DESCRIPTION
## Related Issue:
- #755 

Fixes issue: #755 

## Description:
The font size was adjusted to be larger in order to fix the heading of the blog.

## Screenshots:
Before:
<img width="1223" alt="Screenshot 2024-10-24 at 8 58 46 AM" src="https://github.com/user-attachments/assets/09571932-d2ec-4e84-bb9b-352affdc7331">
After:
<img width="1223" alt="Screenshot 2024-10-24 at 8 58 36 AM" src="https://github.com/user-attachments/assets/c46c1128-057a-4399-9386-e8199162e3f8">
