### PR TITLE
Fix placeholder contrast and toggle design in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -511,7 +511,7 @@ button:hover {
 .header .search-form input {
   width: 100%;
   font-size: 1.6rem;
-  color: var(--text-color);
+  color: black;
   padding: 0.5rem;
   border: none;
   outline: none;


### PR DESCRIPTION
### Fix: Placeholder Contrast & Dark Mode Toggle Design

**Description**
- Improved the contrast of the placeholder text in dark mode to make it more visible and user-friendly.

**Changes Made**
- Adjusted placeholder text colour to black for better contrast based on both themes.

**Testing**
- Verified placeholder text visibility in both light and dark modes.

**Issue Reference**
Closes #812 

---

### Screenshots 
**Dark Mode**
<img width="575" alt="image" src="https://github.com/user-attachments/assets/42a8949c-fa61-42e1-9d8b-78ae44ea8630">

**Light Mode**
<img width="502" alt="image" src="https://github.com/user-attachments/assets/31b4c76e-c2d9-4789-bcfc-b89f69611869">

### Earlier Dark Mode
<img width="464" alt="image" src="https://github.com/user-attachments/assets/2945dfbf-a3aa-4ead-a15b-b37aee34729e">
